### PR TITLE
Change info on how to contact documentation team

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -72,6 +72,13 @@ To support the translation to other languages see
 
 Maintaining high quality documentation requires time and effort
 and the TYPO3 Documentation Team always appreciates support.
-If you want to support us, please join the documentation
-mailing list/forum (http://forum.typo3.org/index.php/f/44/).
+If you want to support us, please contact us as described in
+the next section.
 
+.. _contact-doc-team:
+
+Contact the Documentation Team
+==============================
+
+For general questions about the documentation get in touch with
+the `Documentation Team <https://typo3.org/community/teams/documentation/#c9886>`__.

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -81,4 +81,4 @@ Contact the Documentation Team
 ==============================
 
 For general questions about the documentation get in touch with
-the `Documentation Team <https://typo3.org/community/teams/documentation/#c9886>`__.
+the `Documentation Team <https://typo3.org/community/teams/documentation>`__.


### PR DESCRIPTION
The old forum link is outdated. Updated the description to the one from this document:
https://docs.typo3.org/m/typo3/guide-installation/master/en-us/Introduction/Index.html