### PR TITLE
Remove empty index

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -67,7 +67,6 @@ their `landing page
    AccessControl/Index
    Languages/Index
    NextSteps/Index
-   genindex
 
 
 Links for this manual


### PR DESCRIPTION
Resolves: #37

---

Not part of commit message:

Since v11 is now current LTS I would not bother creating index for v10 and below. And if index is not filled at all, I would remove empty page.

https://docs.typo3.org/m/typo3/tutorial-editors/10.4/en-us/genindex.html