### PR TITLE
Appearance Screenshot under Behaviour section.

### DIFF
--- a/Documentation/Pages/PageProperties/Index.rst
+++ b/Documentation/Pages/PageProperties/Index.rst
@@ -98,8 +98,6 @@ Behaviour
 
 This tab influences a variety of different aspects of the page.
 
-.. include:: /Images/AutomaticScreenshots/PageProperties/Appearance.rst.txt
-
 Here are some of the common fields of the Behaviour tab:
 
 Link Target


### PR DESCRIPTION
The "Appearance" screen shot was showing under the "Appearance" and "Behaviour"  sections. I removed it under "Behaviour" as it was a picture of the "Appearance" tab. If there is a screenshot available with the "Behaviour" that would be helpful to add.