### PR TITLE
[TASK] Update introduction text on index page

### DIFF
--- a/Documentation/About.rst
+++ b/Documentation/About.rst
@@ -9,30 +9,6 @@
 About this guide
 ================
 
-This guide covers working with content in TYPO3. It includes common tasks an editor might perform, such as working with content elements, editing existing text and images, working with forms, and working with pages.
-
-This guide touches briefly on access restriction concepts, as well as content translation.
-
-.. _prerequisite:
-
-Prerequisite
-============
-
-This guides assumes you have read the :doc:`Getting Started Tutorial <t3start:Index>` and are familiar with the following general :ref:`concepts of TYPO3 CMS<t3start:concepts>`:
-
-* Backend and Frontend
-* General Backend Structure
-* The Page Tree
-* Pages and Page Content
-
-.. _examples:
-
-Examples
-========
-
-The examples in this guide are from a TYPO3 installation based on the `Official Introduction Package
-<https://extensions.typo3.org/extension/introduction/>`__.
-
 .. _credits:
 
 Credits

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -4,6 +4,44 @@
 TYPO3 Tutorial for Editors
 ==========================
 
+Once you've installed TYPO3 using our :doc:`Getting Started Guide <t3start:Index>`;
+the next logical step is to log in to the backend of the CMS and start adding pages and create
+some content.
+
+In the TYPO3 world we often call users who carry out these tasks "Editors".
+
+This guide contains detailed information about all of the common tasks an Editor
+is likely to perform including granting other users access to the backend,
+creating pages, adding content to pages in the form of content elements and
+uploading and managing various file types including images and PDFs.
+
+This guide assumes that you are already familiar with TYPO3. If this is not the case,
+visit the :ref:`concepts of TYPO3<t3start:concepts>` to get started.
+
+All of the examples used in this guide are taken from a TYPO3 installation running
+the `Official Introduction Package <https://extensions.typo3.org/extension/introduction/>`__.
+
+----
+
+**Table of Contents:**
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+
+   Login/Index
+   HelpInside/Index
+   Pages/Index
+   ContentElements/Index
+   ListModule/Index
+   FileModule/Index
+   DeepLinking/Index
+   AccessControl/Index
+   Languages/Index
+   Concepts/Index
+   About
+   NextSteps/Index
+
 :Version:
    |release|
 
@@ -21,30 +59,6 @@ TYPO3 Tutorial for Editors
    |today|
 
 ----
-
-This tutorial explains common editorial tasks like working with pages and
-content using TYPO3 CMS.
-
-----
-
-**Table of Contents:**
-
-.. toctree::
-   :maxdepth: 2
-   :titlesonly:
-
-   About
-   Concepts/Index
-   Login/Index
-   HelpInside/Index
-   Pages/Index
-   ContentElements/Index
-   ListModule/Index
-   FileModule/Index
-   DeepLinking/Index
-   AccessControl/Index
-   Languages/Index
-   NextSteps/Index
 
 .. Meta Menu
 


### PR DESCRIPTION
This commit contains changes to the landing page
and about page.

[+] Update and extend the introduction text used
on the home page
[+] Move content from the about page including info
on prerequisite and examples to the home page
[-]  Move the About & Concepts pages to the bottom
of the navigation menu
[-] Move the generic meta information to the bottom
of the homepage 