### PR TITLE
[TASK] Reintroduce "start" anchors for start pages

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -1,4 +1,5 @@
 .. include:: /Includes.rst.txt
+..  _start:
 
 ===================
 TYPO3 Editors Guide


### PR DESCRIPTION
references: https://github.com/TYPO3-Documentation/T3DocTeam/issues/198
releases: main, 11.5, 10.4