### PR TITLE
[TASK] #101137 - Remove pages.doktype 255 / recycler

### DIFF
--- a/Documentation/Pages/PageTypes/Index.rst
+++ b/Documentation/Pages/PageTypes/Index.rst
@@ -55,9 +55,9 @@ Folder
     other than pages or content elements. It will not display in the frontend.
 
 Recycler
-    This is similar to the :guilabel:`Folder` type, but indicates that the
-    content is meant for removal. There is no clean-up function, it is just a
-    visual indicator.
+    ..  versionchanged:: 13.0
+        The recycler type was removed. As a substitution use the
+        :doc:`recycler module <ext_recycler:Index>`.
 
 Menu separator
     This page type creates a visual separation in the page tree. You can use

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -55,6 +55,7 @@ ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
 ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/
 # ext_fsc            = https://docs.typo3.org/c/typo3/cms-fluid-styled-content/main/en-us/
 ext_indexed_search = https://docs.typo3.org/c/typo3/cms-indexed-search/main/en-us/
+ext_recycler       = https://docs.typo3.org/c/typo3/cms-recycler/main/en-us/
 # ext_rte_ckeditor   = https://docs.typo3.org/c/typo3/cms-rte-ckeditor/main/en-us/
 # ext_scheduler      = https://docs.typo3.org/c/typo3/cms-scheduler/main/en-us/
 ext_seo            = https://docs.typo3.org/c/typo3/cms-seo/main/en-us/


### PR DESCRIPTION
An admonition was chosen (instead of just deleting the content) as the recycler is mentioned in the video above and to avoid confusion about this.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/585
Releases: main