### PR TITLE
[BUGFIX] Remove genindex from TOC

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -154,4 +154,3 @@ the `Official Introduction Package <https://extensions.typo3.org/extension/intro
    :hidden:
 
    Sitemap
-   genindex

--- a/Documentation/Localization.ru_RU/Index.rst
+++ b/Documentation/Localization.ru_RU/Index.rst
@@ -147,5 +147,4 @@
    :hidden:
 
    Sitemap
-   genindex
 

--- a/Documentation/Localization.ru_RU/genindex.rst
+++ b/Documentation/Localization.ru_RU/genindex.rst
@@ -1,7 +1,0 @@
-.. include:: /Includes.rst.txt
-
-======
-Индекс
-======
-
-.. Sphinx will insert here the general index automatically.


### PR DESCRIPTION
The "genindex" file is not available, but referenced in the TOC. This provokes a warning upon rendering. Therefore, remove the reference.

Releases: main, 12.4, 11.5