### PR TITLE
[BUGFIX] Remove meta menu from subpage

### DIFF
--- a/Documentation/Concepts/Index.rst
+++ b/Documentation/Concepts/Index.rst
@@ -68,11 +68,3 @@ The following concepts are of interest:
    FileAbstractionLayer
    Accessibility
    Copyright
-
-.. Meta Menu
-
-.. toctree::
-   :hidden:
-
-   Sitemap
-   genindex

--- a/Documentation/Localization.ru_RU/Concepts/Index.rst
+++ b/Documentation/Localization.ru_RU/Concepts/Index.rst
@@ -68,11 +68,3 @@
    FileAbstractionLayer
    Accessibility
    Copyright
-
-.. Meta Menu
-
-.. toctree::
-   :hidden:
-
-   Sitemap
-   genindex


### PR DESCRIPTION
This avoids the warnings:

    ./Documentation/Concepts/Index.rst:74: WARNING: toctree contains reference to nonexisting document 'Concepts/Sitemap'
    ./Documentation/Concepts/Index.rst:74: WARNING: toctree contains reference to nonexisting document 'Concepts/genindex'

Releases: main, 12.4, 11.5