### PR TITLE
[TASK] Split up "Help within TYPO3" chapter (#161)

### DIFF
--- a/Documentation/HelpInside/BackendSearch/Index.rst
+++ b/Documentation/HelpInside/BackendSearch/Index.rst
@@ -1,0 +1,20 @@
+..  include:: /Includes.rst.txt
+
+..  _backend-search:
+
+==============
+Backend search
+==============
+
+The backend search tool accepts text and searches against
+various types of records in the backend.
+
+The search can be opened by selecting the magnifying glass in the top right
+corner of the toolbar or - starting with TYPO3 v12 - by hitting :kbd:`Shift`
+twice in a row.
+
+..  figure:: /Images/ManualScreenshots/Help/BackendSearch.png
+    :alt: The backend search modal with some search results
+    :class: with-border
+
+    The backend search modal with some search results

--- a/Documentation/HelpInside/Index.rst
+++ b/Documentation/HelpInside/Index.rst
@@ -1,85 +1,24 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. _help-inside:
+..  _help-inside:
 
-=====================
-Help within TYPO3 CMS
-=====================
-
-There are several features built-in to the user interface of the backend to
-help guide you when using the TYPO3 CMS.
-
-.. versionchanged:: 12.0
-   The context sensitive help, also called "CSH" has been removed as it was
-   outdated and not maintained. Refer to the
-   :ref:`typo3-online-documentation` instead.
-
-Tooltips
-========
-
-Hover your mouse pointer over buttons and icons to display a short description of the function.
-
-.. figure:: /Images/ManualScreenshots/Help/Tooltip.png
-   :alt: Tooltip for the Forms module
-   :class: with-border
-
-   See the Tooltip help for the Forms module
-
-.. _typo3-online-documentation:
-
-TYPO3 online documentation
-===========================
-
-You can find the startpage of the official TYPO3 documentation at
-https://docs.typo3.org/ .
-
-You can conveniently open this documentation from your TYPO3 backend:
-
-In the top bar, click the question mark icon to access the
-Help section, then select the :guilabel:`TYPO3 Online Documentation` module.
-
-.. figure:: /Images/ManualScreenshots/Help/Typo3OnlineDocumentation.png
-   :alt: The TYPO3 Online Documentation in the Help menu
-   :class: with-border
-
-   The :guilabel:`TYPO3 Online Documentation` in the :guilabel:`Help` menu
-
-
-Keyboard commands
+=================
+Help within TYPO3
 =================
 
-Tooltips
-========
+There are several features built-in to the user interface of the backend to
+help guide you when using the TYPO3.
 
-Hover your mouse pointer over buttons and icons to display a short description of the function.
+..  versionchanged:: 12.0
+    The context sensitive help, also called "CSH" has been removed as it was
+    outdated and not maintained. Refer to the
+    :ref:`typo3-online-documentation` instead.
 
-.. figure:: /Images/ManualScreenshots/Help/Tooltip.png
-   :alt: Tooltip for the Forms module
-   :class: with-border
+Topics
+======
 
-   See the Tooltip help for the Forms module
+..  toctree::
+    :titlesonly:
+    :glob:
 
-.. _backend-search:
-
-Backend search
-==============
-
-The backend search tool accepts text and searches against
-various types of records in the backend.
-
-The search can be opened by selecting the magnifying glass in the top right corner of
-the toolbar or - starting with TYPO3 v12 - by hitting :kbd:`Shift` twice in a
-row.
-
-..  figure:: /Images/ManualScreenshots/Help/BackendSearch.png
-    :alt: The backend search modal with some search results.
-    :class: with-border
-
-    The backend search modal with some search results.
-
-.. toctree::
-   :maxdepth: 5
-   :titlesonly:
-   :glob:
-
-   KeyboardCommands/Index
+    */Index

--- a/Documentation/HelpInside/OnlineDocumentation/Index.rst
+++ b/Documentation/HelpInside/OnlineDocumentation/Index.rst
@@ -1,0 +1,21 @@
+..  include:: /Includes.rst.txt
+
+..  _typo3-online-documentation:
+
+==========================
+TYPO3 online documentation
+==========================
+
+You can find the startpage of the official TYPO3 documentation at
+https://docs.typo3.org/ .
+
+You can conveniently open this documentation from your TYPO3 backend:
+
+In the top bar, click the question mark icon to access the
+Help section, then select the :guilabel:`TYPO3 Online Documentation` module.
+
+..  figure:: /Images/ManualScreenshots/Help/Typo3OnlineDocumentation.png
+    :alt: The TYPO3 Online Documentation in the Help menu
+    :class: with-border
+
+    The :guilabel:`TYPO3 Online Documentation` in the :guilabel:`Help` menu

--- a/Documentation/HelpInside/Tooltips/Index.rst
+++ b/Documentation/HelpInside/Tooltips/Index.rst
@@ -1,0 +1,16 @@
+..  include:: /Includes.rst.txt
+
+..  _tooltips:
+
+========
+Tooltips
+========
+
+Hover your mouse pointer over buttons and icons to display a short description
+ of the function.
+
+..  figure:: /Images/ManualScreenshots/Help/Tooltip.png
+    :alt: Tooltip for the Forms module
+    :class: with-border
+
+    See the Tooltip help for the Forms module


### PR DESCRIPTION
Previously, the keyboard commands were already a separate page which was displayed as a link at the bottom of a page and can easily overlooked. As the keyboard commands chapter is already a bit longer, the other topics have been moved to separate pages (instead of integrating the keyboard commands into the existing page). This also leaves room for improvement of each topic.

Releases: main, 12.4