### PR TITLE
[FEATURE] Rename top-level module "web" to "content"

### DIFF
--- a/Documentation/AccessControl/Login/Index.rst
+++ b/Documentation/AccessControl/Login/Index.rst
@@ -34,7 +34,7 @@ Create a user group and user
 
    .. include:: /Images/AutomaticScreenshots/Access/AccessUserFolder.rst.txt
 
-#. Navigate to the :guilabel:`Web > List` module, and select your new folder.
+#. Navigate to the :guilabel:`Content > List` module, and select your new folder.
 #. Click the **+** :guilabel:`Create new record` icon at the top left of the
    Docheader. The "New record" wizard displays.
 
@@ -76,7 +76,7 @@ the page properties or content element properties.
    * The "Show at any login" group is used for elements that require
      authentication to access, but are okay for all groups to see.
 
-#. Navigate to the :guilabel:`Web > Page` module, and create a new page called
+#. Navigate to the :guilabel:`Content > Page` module, and create a new page called
    "Members only".
 #. Add a text content element to the Members Only page, with text similar to
    "You need to authenticate to access the members area".

--- a/Documentation/Concepts/Cache.rst
+++ b/Documentation/Concepts/Cache.rst
@@ -78,7 +78,7 @@ Manual cache clearing
 Clearing the cache of a single page can be done without ill effect in most
 installations.
 
-To clear the cache of that page, go to the module :guilabel:`Web > Page`
+To clear the cache of that page, go to the module :guilabel:`Content > Page`
 and click the button representing a lightning bolt with the tooltip
 :guilabel:`Clear cache for this page`.
 

--- a/Documentation/ContentElements/ContactForm/Index.rst
+++ b/Documentation/ContentElements/ContactForm/Index.rst
@@ -13,7 +13,7 @@ Creating a contact form
     :class: img-thumbnail float-end ms-1 ms-1
     :width: 250
 
-You can create a form from the :guilabel:`Web > Forms` module. This is a
+You can create a form from the :guilabel:`Content > Forms` module. This is a
 system extension which needs to be activated by your administrator. It is
 written in TypoScript and is fully documented in the :doc:`Form Framework <ext_form:Index>` system extension manual.
 
@@ -21,7 +21,7 @@ This module provides a guided interface for editors to create any kind of form
 such as a contact form, newsletter subscription or even a survey. TYPO3 comes
 with one pre-defined form already built, which you can use to get started.
 
-#. In the :guilabel:`Web > Forms` module, click the :guilabel:`+ Create new
+#. In the :guilabel:`Content > Forms` module, click the :guilabel:`+ Create new
    form` button. The :guilabel:`Create new form` wizard displays.
 
    .. include:: /Images/AutomaticScreenshots/Forms/FormCreateNew.rst.txt
@@ -70,7 +70,7 @@ with one pre-defined form already built, which you can use to get started.
 Create a form from scratch
 ==========================
 
-#. In the :guilabel:`Web > Forms` module, click the :guilabel:`+ Create new
+#. In the :guilabel:`Content > Forms` module, click the :guilabel:`+ Create new
    form` button.
 #. In the :guilabel:`Create new form` wizard, choose to create a blank form.
 #. Give your form a name, then click :guilabel:`Next` and :guilabel:`Finish`.

--- a/Documentation/ContentElements/Content/Index.rst
+++ b/Documentation/ContentElements/Content/Index.rst
@@ -15,7 +15,12 @@ Managing content
     :class: img-thumbnail float-end ms-1 ms-1
     :width: 250
 
-In TYPO3, working with content happens mostly in the :guilabel:`Web > Page`
+..  versionchanged:: 14.0
+    The main module `Web` has been renamed to `Content`.
+    See `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_
+
+
+In TYPO3, working with content happens mostly in the :guilabel:`Content > Page`
 module. Chose the page you want to edit from the page tree.
 
 You can `Hide <https://docs.typo3.org/permalink/t3editors:content-working-hiding>`_.
@@ -164,7 +169,7 @@ Restore deleted content elements using the Recycler
 ---------------------------------------------------
 
 If you accidentally delete a content element or even a complete page you can
-restore your data using the module :guilabel:`Web > Recycler` if you have
+restore your data using the module :guilabel:`Content > Recycler` if you have
 sufficient permissions and it is installed.
 
 ..  figure:: /Images/ManualScreenshots/ContentElements/RestoreContent.png

--- a/Documentation/ContentElements/CreatingContent/Index.rst
+++ b/Documentation/ContentElements/CreatingContent/Index.rst
@@ -16,7 +16,12 @@ Creating content
     :class: img-thumbnail float-end ms-1 ms-1
     :width: 250
 
-In the :guilabel:`Web > Page` module, on any page, click the :guilabel:`+
+..  versionchanged:: 14.0
+    The main module `Web` has been renamed to `Content`.
+    See `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_
+
+
+In the :guilabel:`Content > Page` module, on any page, click the :guilabel:`+
 Create new content` button in the place where you want to insert content:
 
 The :guilabel:`New Page Content` wizard will then be displayed.
@@ -178,4 +183,3 @@ Add new content to a page
     The new content element appears in the Page module
 
 ..  include:: /ContentElements/TipKeyboardCommands.rst.txt
-

--- a/Documentation/FileModule/Index.rst
+++ b/Documentation/FileModule/Index.rst
@@ -23,7 +23,7 @@ Managing files in the TYPO3 CMS
 ===============================
 
 Files including documents and images are managed in the
-Filelist module. Similar to the :guilabel:`Web > List` module,
+Filelist module. Similar to the :guilabel:`Content > List` module,
 it displays a navigation tree, which corresponds to the file
 structure on the server, and a list of all files for the
 selected directory.
@@ -96,4 +96,3 @@ Next steps
 The next chapters cover configuration and administration tasks that
 require special access privileges as described in :ref:`Access control in the
 backend (users and groups) <t3coreapi:access>`.
-

--- a/Documentation/Languages/Index.rst
+++ b/Documentation/Languages/Index.rst
@@ -65,7 +65,7 @@ Working with translations
 =========================
 
 #. Working with the `Introduction Package <https://extensions.typo3.org/
-   extension/introduction/>`__, in the :guilabel:`Web > Pages` module, go to the "Congratulations" home page.
+   extension/introduction/>`__, in the :guilabel:`Content > Pages` module, go to the "Congratulations" home page.
 #. Using the menu in the docheader, switch to the "Languages" view.
 
    .. figure:: ../Images/ManualScreenshots/Language/LanguagesPageLanguages.png

--- a/Documentation/ListModule/UsingEffectively/Index.rst
+++ b/Documentation/ListModule/UsingEffectively/Index.rst
@@ -5,11 +5,15 @@
 Using the list module
 =====================
 
-The :guilabel:`Web > List` module allows you to browse through pages and folders
+..  versionchanged:: 14.0
+    The main module `Web` has been renamed to `Content`.
+    See `Feature: #107628 - Improved backend module naming and structure <https://docs.typo3.org/permalink/changelog:feature-107628-1729026000>`_
+
+The :guilabel:`Content > List` module allows you to browse through pages and folders
 in your site and view the records that
 are stored there. You can also create and edit records.
 
-Select the :guilabel:`Web > List` module and choose a page or storage folder.
+Select the :guilabel:`Content > List` module and choose a page or storage folder.
 
 ..  contents:: Table of Contents
 

--- a/Documentation/Pages/CreatingPages/Index.rst
+++ b/Documentation/Pages/CreatingPages/Index.rst
@@ -17,7 +17,7 @@ an existing page and using the contextual menu.
 
 To start adding pages:
 
-* Select the :guilabel:`Web > Page` module in the backend.
+* Select the :guilabel:`Content > Page` module in the backend.
 * Expand the page tree so that all of its subpages are visible (optional).
 
 

--- a/Documentation/SearchEngineOptimization/Index.rst
+++ b/Documentation/SearchEngineOptimization/Index.rst
@@ -15,13 +15,13 @@ All the following fields are part of the page record.
 
 You can reach it by:
 
-*   Open the :guilabel:`Web > Page` module
+*   Open the :guilabel:`Content > Page` module
 *   Use the pen (`Edit page properties`) in the top bar icon to edit the
     page record.
 
 An alternative way is to use the context menu.
 
-*   Open :guilabel:`Web > Page` module
+*   Open :guilabel:`Content > Page` module
 *   Right click the page you want to edit in the page tree
 *   Select the Edit action
 


### PR DESCRIPTION
References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1373
Releases: main