### PR TITLE
[TASK] Migrate backport and documentation workflows to shared reusable workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,9 +11,6 @@ permissions:
 
 jobs:
   backport:
-    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@9d884304b1a5cdeeb2e21349a5bbfe52da5548d5
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@main
     with:
       label_pattern: "^backport (.+)$"
-    secrets:
-      APP_ID: ${{ secrets.APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   backport:
-    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@161f3bed5308099b67674e3e9d5a735e02500b24
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@main
     with:
       label_pattern: "^backport (.+)$"
     secrets:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,17 +1,11 @@
 name: Test documentation
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
 
 jobs:
-  tests:
-    name: Render documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Test if the documentation will render without warnings
-        run: |
-          mkdir -p Documentation-GENERATED-temp \
-          && docker run --rm --pull always -v $(pwd):/project \
-             ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test
+  render:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-test-documentation.yml@main
+    with:
+      render-flags: '--no-progress --minimal-test'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,17 +1,11 @@
 name: Test documentation
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
 
 jobs:
-  tests:
-    name: Render documentation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-
-      - name: Test if the documentation will render without warnings
-        run: |
-          mkdir -p Documentation-GENERATED-temp \
-          && docker run --rm --pull always -v $(pwd):/project \
-             ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test
+  render:
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-test-documentation.yml@main
+    with:
+      render-flags: '--no-progress --minimal-test'


### PR DESCRIPTION
## Summary

Migrates both workflow files to shared reusable workflows from
[TYPO3-Documentation/.github](https://github.com/TYPO3-Documentation/.github).

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| backport.yml | 22 lines inline | `reusable-backport.yml` (5 lines) |
| documentation.yml | 15 lines inline | `reusable-test-documentation.yml` (8 lines) |

## Benefits

- **Single point of maintenance** — action version updates happen centrally
- **Consistent configuration** — all documentation repos test rendering the same way
- **No allow-list concerns** — .github workflows are automatically trusted

## Dependencies and merge order

- Depends on .github#4 (backport label_pattern fix)
- Depends on .github#2 (adds `reusable-test-documentation.yml`)