### PR TITLE
Rename page type "Link to external URL" to "Link"

### DIFF
--- a/Documentation/Pages/PageTypes/Index.rst
+++ b/Documentation/Pages/PageTypes/Index.rst
@@ -43,7 +43,7 @@ Mount point
     See the :ref:`Mounts <t3coreapi:access-options-mounts>` section in "TYPO3
     Explained" for more information about mount points.
 
-Link to External URL
+Link
     This page type is similar to the :guilabel:`Shortcut` type but leads the
     user to a page on another web site.
 


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Feature-17406-EnhancePageTypeLinkToFullySupportTypolinks.html#feature-17406-enhance-page-type-link-to-fully-support-typolinks