### PR TITLE
[DOCS] Update page type 'link to external url' to 'link'

### DIFF
--- a/Documentation/Pages/PageTypes/Index.rst
+++ b/Documentation/Pages/PageTypes/Index.rst
@@ -51,7 +51,7 @@ Mount point
 
 Link
     This page type is similar to the :guilabel:`Shortcut` type but leads the
-    user to external URLs, other pages, content elements, sections, files,
+    user to external URLs, other pages, content elements, files,
     folders, email addresses or custom records (for example news records).
 
 Special

--- a/Documentation/Pages/PageTypes/Index.rst
+++ b/Documentation/Pages/PageTypes/Index.rst
@@ -10,6 +10,12 @@ Page types
 
 ------------
 
+..  versionchanged:: 14.0
+    The former page type `Link to External URL` has changed its name to `Link`
+    and has a lot more features now.
+    See
+    :ref:`Feature: #17406 - Enhance page type "Link" to fully support typolinks <changelog:feature-17406-1762953087>`
+
 Default page types
 ==================
 
@@ -43,9 +49,10 @@ Mount point
     See the :ref:`Mounts <t3coreapi:access-options-mounts>` section in "TYPO3
     Explained" for more information about mount points.
 
-Link to External URL
+Link
     This page type is similar to the :guilabel:`Shortcut` type but leads the
-    user to a page on another web site.
+    user to external URLs, other pages, content elements, sections, files,
+    folders, email addresses or custom records (for example news records).
 
 Special
 -------

--- a/Documentation/Pages/PageTypes/Index.rst
+++ b/Documentation/Pages/PageTypes/Index.rst
@@ -12,7 +12,7 @@ Page types
 
 ..  versionchanged:: 14.0
     The former page type `Link to External URL` has changed its name to `Link`
-    and has a lot more features now.
+    and has a lot more features.
     See
     :ref:`Feature: #17406 - Enhance page type "Link" to fully support typolinks <changelog:feature-17406-1762953087>`
 


### PR DESCRIPTION
Update Patch for [old PR](https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-Editors/pull/280). 
Additionally it solves a part of the issue: [Enhance page type Link to fully support typolinks](https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1494). 